### PR TITLE
Support releasing ROS 2 packages

### DIFF
--- a/.github/workflows/alpine-ros2-release.yaml
+++ b/.github/workflows/alpine-ros2-release.yaml
@@ -1,13 +1,13 @@
-# Release ROS 1 package to Alpine ROS.
+# Release ROS 2 package to Alpine ROS.
 
-name: Alpine ROS 1 release workflow
+name: Alpine ROS 2 release workflow
 on:
   workflow_call:
     inputs:
       ros-distro:
         description: "ROS distribution name"
         type: string
-        default: noetic
+        required: true
       source-repo-slug:
         description: "Package repository slug"
         type: string
@@ -27,15 +27,15 @@ on:
       rosdistro-repo-slug:
         description: "Upstream rosdistro repository slug"
         type: string
-        default: alpine-ros/rosdistro1
+        default: alpine-ros/rosdistro
       rosdistro-repo-branch:
         description: "Upstream rosdistro repository branch"
         type: string
-        default: main
+        default: alpine-custom-apk
       rosdistro-fork-slug:
-        description: "Rosdistro repository slug to push PR branches. You need to fork alpine-ros/rosdistro1 beforehand"
+        description: "Rosdistro repository slug to push PR branches. You need to fork alpine-ros/rosdistro beforehand"
         type: string
-        default: ${{ github.repository_owner }}/rosdistro1
+        default: ${{ github.repository_owner }}/rosdistro
       manifest-files:
         description: "Package manifet files to be released. Automatically detected if not specified"
         type: string
@@ -69,7 +69,7 @@ on:
         required: false
 
 jobs:
-  alpine-ros1-release:
+  alpine-ros2-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/alpine-ros2-release.yaml
+++ b/.github/workflows/alpine-ros2-release.yaml
@@ -45,7 +45,7 @@ on:
         type: boolean
         default: true
       git-user:
-        description: "Git user name to commit release data nad rosdistro update"
+        description: "Git user name to commit release data and rosdistro update"
         type: string
         required: true
       git-email:

--- a/.github/workflows/alpine-ros2-release.yaml
+++ b/.github/workflows/alpine-ros2-release.yaml
@@ -27,7 +27,7 @@ on:
       rosdistro-repo-slug:
         description: "Upstream rosdistro repository slug"
         type: string
-        default: alpine-ros/rosdistro
+        required: true
       rosdistro-repo-branch:
         description: "Upstream rosdistro repository branch"
         type: string

--- a/.github/workflows/alpine-ros2-release.yaml
+++ b/.github/workflows/alpine-ros2-release.yaml
@@ -49,7 +49,7 @@ on:
         type: string
         required: true
       git-email:
-        description: "Git email to commit release data nad rosdistro update"
+        description: "Git email to commit release data and rosdistro update"
         type: string
         required: true
       repository:

--- a/.github/workflows/internal.test-alpine-ros2-release.yaml
+++ b/.github/workflows/internal.test-alpine-ros2-release.yaml
@@ -1,0 +1,31 @@
+name: ci
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ros-distro: [humble, jazzy]
+    uses: ./.github/workflows/alpine-ros2-release.yaml
+    with:
+      ros-distro: ${{ matrix.ros-distro }}
+      source-repo-slug: alpine-ros/sample2-ros-pkg
+      source-branch: main
+      release-ref: 0.0.0
+      release-repo-slug: alpine-ros/sample2-ros-pkg-release
+      rosdistro-repo-slug: alpine-ros/rosdistro
+      rosdistro-repo-branch: alpine-custom-apk
+      rosdistro-fork-slug: alpine-ros-bot/rosdistro
+      git-user: alpine-ros-bot
+      git-email: 214657941+alpine-ros-bot@users.noreply.github.com
+      action-ref: ${{ github.head_ref }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/internal.test-alpine-ros2-release.yaml
+++ b/.github/workflows/internal.test-alpine-ros2-release.yaml
@@ -17,10 +17,10 @@ jobs:
     uses: ./.github/workflows/alpine-ros2-release.yaml
     with:
       ros-distro: ${{ matrix.ros-distro }}
-      source-repo-slug: alpine-ros/sample2-ros-pkg
+      source-repo-slug: alpine-ros/sample-ros2-pkg
       source-branch: main
       release-ref: 0.0.0
-      release-repo-slug: alpine-ros/sample2-ros-pkg-release
+      release-repo-slug: alpine-ros/sample-ros2-pkg-release
       rosdistro-repo-slug: alpine-ros/rosdistro
       rosdistro-repo-branch: alpine-custom-apk
       rosdistro-fork-slug: alpine-ros-bot/rosdistro

--- a/scripts/alpine-ros-release.sh
+++ b/scripts/alpine-ros-release.sh
@@ -264,7 +264,7 @@ case ${answer:0:1} in
     ;;
 esac
 
-echo "Pushing to rosdistro1 fork: ${release_branch_name}"
+echo "Pushing to rosdistro fork: ${release_branch_name}"
 git -C ${rosdistro_tmp} push fork ${release_branch_name}
 
 sleep 1


### PR DESCRIPTION
```patch
$ diff .github/workflows/alpine-ros2-release.yaml .github/workflows/alpine-ros1-release.yaml 
1c1
< # Release ROS 2 package to Alpine ROS.
---
> # Release ROS 1 package to Alpine ROS.
3c3
< name: Alpine ROS 2 release workflow
---
> name: Alpine ROS 1 release workflow
10c10
<         required: true
---
>         default: noetic
30c30
<         default: alpine-ros/rosdistro
---
>         default: alpine-ros/rosdistro1
34c34
<         default: alpine-custom-apk
---
>         default: main
36c36
<         description: "Rosdistro repository slug to push PR branches. You need to fork alpine-ros/rosdistro beforehand"
---
>         description: "Rosdistro repository slug to push PR branches. You need to fork alpine-ros/rosdistro1 beforehand"
38c38
<         default: ${{ github.repository_owner }}/rosdistro
---
>         default: ${{ github.repository_owner }}/rosdistro1
72c72
<   alpine-ros2-release:
---
>   alpine-ros1-release:
```